### PR TITLE
Remove twice call to test-jar goal

### DIFF
--- a/network/common/pom.xml
+++ b/network/common/pom.xml
@@ -90,7 +90,7 @@
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
       <!-- Create a test-jar so network-shuffle can depend on our test utilities. -->
-      <plugin>
+      <!--<plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
@@ -102,7 +102,7 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
+      </plugin>-->
     </plugins>
   </build>
 </project>

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -85,7 +85,7 @@
            causes the compilation to fail if catalyst test-jar is not generated. Hence, the
            second execution profile for 'mvn test-compile'.
       -->
-      <plugin>
+      <!--<plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
@@ -102,7 +102,7 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
+      </plugin>-->
     </plugins>
   </build>
   <profiles>

--- a/streaming/pom.xml
+++ b/streaming/pom.xml
@@ -106,9 +106,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
+        <!--<configuration>
           <shadeTestJar>true</shadeTestJar>
-        </configuration>
+        </configuration>-->
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
When executing the deploy maven lifecycle to push jars to our internal nexus we are faincg this issue:
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project spark-network-common_2.10: Failed to deploy artifacts: Could not transfer artifact org.apache.spark:spark-network-common_2.10:jar:tests:1.6.3 from/to criteo (http://localhost:8081/nexus/content/repositories/criteo/): Failed to transfer file: http://localhost:8081/nexus/content/repositories/criteo/org/apache/spark/spark-network-common_2.10/1.6.3/spark-network-common_2.10-1.6.3-tests.jar. Return code is: 400, ReasonPhrase: Bad Request. -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project spark-network-common_2.10: Failed to deploy artifacts: Could not transfer artifact org.apache.spark:spark-network-common_2.10:jar:tests:1.6.3 from/to criteo (http://localhost:8081/nexus/content/repositories/criteo/): Failed to transfer file: http://localhost:8081/nexus/content/repositories/criteo/org/apache/spark/spark-network-common_2.10/1.6.3/spark-network-common_2.10-1.6.3-tests.jar. Return code is: 400, ReasonPhrase: Bad Request.

This is due to the spark-network-common_2.10-1.6.3-tests.jar behing uploaded twice to the nexus repo:
Uploading: http://localhost:8081/nexus/content/repositories/criteo/org/apache/spark/spark-network-common_2.10/1.6.3/spark-network-common_2.10-1.6.3-tests.jar
Uploaded: http://localhost:8081/nexus/content/repositories/criteo/org/apache/spark/spark-network-common_2.10/1.6.3/spark-network-common_2.10-1.6.3-tests.jar (77 KB at 5465.8 KB/sec)
Uploading: http://localhost:8081/nexus/content/repositories/criteo/org/apache/spark/spark-network-common_2.10/1.6.3/spark-network-common_2.10-1.6.3-tests.jar

The root cause is due to the test-jar goal being called in 2 phases "test-compile" and "test-jar" from the root pom.xml and from the spark-network-common pom.xml.

To solve this we can remove the call to the test-goal on the 3 spark submodules or we can ensure that none of the tests jar are compiled and send to the nexus adding this parameter -Dmaven.test.skip=true to the deploy lifecycle (install lifecycle should be run first)

Let's discuss about what we want to implement in this pull request.
