### PR TITLE
Destroying a broadcasted variable in LBFGS CostFun

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
@@ -226,6 +226,9 @@ object LBFGS extends Logging {
             (grad1, loss1 + loss2)
           })
 
+      // broadcasted model is not needed anymore
+      bcW.destroy()
+
       /**
        * regVal is sum of weight squares if it's L2 updater;
        * for other updater, the same logic is followed.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding a .destroy() call for a broadcasted variable that is neither re-used nor destroyed. This variable contains the vector of learned weights before the current iteration and can be relatively large; moreover these weights are broadcasted on each LBFGS iteration.
## How was this patch tested?

Manual tests & unit tests.
