### PR TITLE
Add a script to build the criteo distribution of spark

### DIFF
--- a/dev/criteo/make-criteo-distribution.sh
+++ b/dev/criteo/make-criteo-distribution.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+SPARK_HOME="$(cd "`dirname "$0"`"; cd ../..; pwd)"
+
+$SPARK_HOME/make-distribution.sh --name criteo --tgz -Pyarn -Phadoop-2.6 -Dhadoop.version=2.6.0-cdh5.5.0 -Phive -Phive-thriftserver


### PR DESCRIPTION
Add a script in dev/criteo to build the criteo distribution of Spark

Tested locally to build the spark distribution.
