### PR TITLE
[SPARK-18119][SPARK-CORE] Namenode safemode check is only performed on one namenode which can stuck the startup of SparkHistory server

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -674,8 +674,16 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       }
 
     val action = actionClass.getField("SAFEMODE_GET").get(null)
-    val method = dfs.getClass().getMethod("setSafeMode", action.getClass())
-    method.invoke(dfs, action).asInstanceOf[Boolean]
+
+    try {
+      val method = dfs.getClass().getMethod("setSafeMode", action.getClass(),
+        java.lang.Boolean.TYPE)
+      method.invoke(dfs, action, true: java.lang.Boolean).asInstanceOf[Boolean]
+    } catch {
+      case _: NoSuchMethodException =>
+        val method = dfs.getClass().getMethod("setSafeMode", action.getClass())
+        method.invoke(dfs, action).asInstanceOf[Boolean]
+    }
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of using the setSafeMode method that check the first namenode used the one which permitts to check only for active NNs
## How was this patch tested?

manual tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

This commit is contributed by Criteo SA under the Apache v2 licence.
