### PR TITLE
[SPARK-19353][CORE] Generalize PipedRDD to use I/O formats

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -773,12 +773,41 @@ abstract class RDD[T: ClassTag](
       separateWorkingDir: Boolean = false,
       bufferSize: Int = 8192,
       encoding: String = Codec.defaultCharsetCodec.name): RDD[String] = withScope {
-    new PipedRDD(this, command, env,
+    val inputWriter = new TextInputWriter[T](
+      encoding,
       if (printPipeContext ne null) sc.clean(printPipeContext) else null,
-      if (printRDDElement ne null) sc.clean(printRDDElement) else null,
+      if (printRDDElement ne null) sc.clean(printRDDElement) else null)
+    val outputReader = new TextOutputReader(encoding)
+    pipeFormatted(command, env, separateWorkingDir, bufferSize, inputWriter, outputReader)
+  }
+
+  /**
+   * Return an RDD created by piping elements to a forked external process. The resulting RDD
+   * is computed by executing the given process once per partition. All elements
+   * of each input partition are written to a process's stdin. The resulting partition
+   * consists of the process's stdout output.
+   *
+   * @param command command to run in forked process.
+   * @param env environment variables to set.
+   * @param separateWorkingDir Use separate working directories for each task.
+   * @param bufferSize Buffer size for the stdin writer for the piped process.
+   * @param inputWriter the format to use for serializing the elements of this RDD into
+   *                    the process's stdin.
+   * @param outputReader the format to use for reading elements into the resulting RDD
+   *                     from process's stdout.
+   * @return the result RDD
+   */
+  def pipeFormatted[O: ClassTag](
+      command: Seq[String],
+      env: Map[String, String] = Map(),
+      separateWorkingDir: Boolean = false,
+      bufferSize: Int = 8192,
+      inputWriter: InputWriter[T],
+      outputReader: OutputReader[O]): RDD[O] = withScope {
+    new PipedRDD(this, command, env,
       separateWorkingDir,
       bufferSize,
-      encoding)
+      inputWriter, outputReader)
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
@@ -17,10 +17,9 @@
 
 package org.apache.spark.rdd
 
-import java.io.File
+import java.io.{DataInput, DataOutput, File}
 
 import scala.collection.Map
-import scala.io.Codec
 import scala.sys.process._
 import scala.util.Try
 
@@ -232,16 +231,7 @@ class PipedRDDSuite extends SparkFunSuite with SharedSparkContext {
         }
       }
       val hadoopPart1 = generateFakeHadoopPartition()
-      val pipedRdd =
-        new PipedRDD(
-          nums,
-          PipedRDD.tokenize("printenv " + varName),
-          Map(),
-          null,
-          null,
-          false,
-          4092,
-          Codec.defaultCharsetCodec.name)
+      val pipedRdd = nums.pipe("printenv " + varName)
       val tContext = TaskContext.empty()
       val rddIter = pipedRdd.compute(hadoopPart1, tContext)
       val arr = rddIter.toArray
@@ -257,4 +247,66 @@ class PipedRDDSuite extends SparkFunSuite with SharedSparkContext {
     new HadoopPartition(sc.newRddId(), 1, split)
   }
 
+  test("pipe works for non-default encoding") {
+    if (testCommandAvailable("cat")) {
+      val elems = sc.parallelize(Array("foobar"))
+          .pipe(Seq("cat"), encoding = "utf-32")
+          .collect()
+
+      assert(elems.size === 1)
+      assert(elems.head === "foobar")
+    }
+  }
+
+  test("pipe works for null") {
+    if (testCommandAvailable("cat")) {
+      val elems = sc.parallelize(Array(null))
+          .pipe(Seq("cat"))
+          .collect()
+
+      assert(elems.size === 1)
+      assert(elems.head === "null")
+    }
+  }
+
+  test("pipe works for rawbytes") {
+    if (testCommandAvailable("cat")) {
+      val kv = "foo".getBytes -> "bar".getBytes
+      val elems = sc.parallelize(Array(kv)).pipeFormatted(Seq("cat"),
+        inputWriter = new RawBytesInputWriter(),
+        outputReader = new RawBytesOutputReader()
+      ).collect()
+
+      assert(elems.size === 1)
+      val Array((key, value)) = elems
+      assert(key sameElements kv._1)
+      assert(value sameElements kv._2)
+    }
+  }
+}
+
+class RawBytesInputWriter extends InputWriter[(Array[Byte], Array[Byte])] {
+  override def write(dos: DataOutput, elem: (Array[Byte], Array[Byte])): Unit = {
+    val (key, value) = elem
+    dos.writeInt(key.length)
+    dos.write(key)
+    dos.writeInt(value.length)
+    dos.write(value)
+  }
+}
+
+class RawBytesOutputReader extends OutputReader[(Array[Byte], Array[Byte])] {
+  private def readLengthPrefixed(dis: DataInput): Array[Byte] = {
+    val length = dis.readInt()
+    assert(length >= 0)
+    val result = Array.ofDim[Byte](length)
+    dis.readFully(result)
+    result
+  }
+
+  override def read(dis: DataInput): (Array[Byte], Array[Byte]) = {
+    val key = readLengthPrefixed(dis)
+    val value = readLengthPrefixed(dis)
+    key -> value
+  }
 }


### PR DESCRIPTION
This commit allows to use arbitrary input and output formats when
streaming data to and from the piped process. The API uses
java.io.Data{Input,Output} for I/O, therefore all method operating
on multibyte primitives assume big-endian byte order.

The change is fully backward-compatible in terms of both public API
and behaviour. Additionally, existing line-based format is available
via TextInputWriter/TextOutputReader.