### PR TITLE
[CRITEO - Scala 2.10 Fix] Fixed non-serializable error in JavaMultilayerPerceptronClassifierSuite

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -377,7 +377,10 @@ class SparkSession private(
     val attrSeq = getSchema(beanClass)
     val beanInfo = Introspector.getBeanInfo(beanClass)
     val rows = SQLContext.beansToRows(data.asScala.iterator, beanInfo, attrSeq)
-    Dataset.ofRows(self, LocalRelation(attrSeq, rows.toSeq))
+    // XXX [[Iterator.toSeq]] creates a closure over non-serializable
+    //     [[java.util.ListIterator]] which on Scala 2.10 could break
+    //     closure serialization.
+    Dataset.ofRows(self, LocalRelation(attrSeq, rows.toList))
   }
 
   /**


### PR DESCRIPTION
I have failed to find the change between Scala 2.10 and 2.11 causing this, but operationally the issue originates from `SparkSession.createDataFrame` which creates a (lazy!) `Seq`
referencing a non-serializable `java.util.ListIterator`.

I suspect one of the collection traits was change, but given how many of them are in the standard library, it is hard to tell which one. Here is a potential candidate
scala/scala@0bb8a139e9c46e3e1b4bd7af5dd11cb689ebbe8e.