### PR TITLE
[HDP-6774] Fixing the failing tests in Spark build by replacing the d…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -283,7 +283,7 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>selenium-htmlunit-driver</artifactId>
+      <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- Added for selenium: -->

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -35,7 +35,7 @@ import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods
 import org.json4s.jackson.JsonMethods._
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.htmlunit.HtmlUnitDriver
+import org.openqa.selenium.chrome.ChromeDriver
 import org.scalatest.{BeforeAndAfter, Matchers}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mock.MockitoSugar
@@ -317,9 +317,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     contextHandler.addServlet(holder, "/")
     server.attachHandler(contextHandler)
 
-    implicit val webDriver: WebDriver = new HtmlUnitDriver(true) {
-      getWebClient.getOptions.setThrowExceptionOnScriptError(false)
-    }
+    implicit val webDriver: WebDriver = new ChromeDriver
 
     try {
       val url = s"http://localhost:$port"
@@ -351,7 +349,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
 
   test("incomplete apps get refreshed") {
 
-    implicit val webDriver: WebDriver = new HtmlUnitDriver
+    implicit val webDriver: WebDriver = new ChromeDriver
     implicit val formats = org.json4s.DefaultFormats
 
     // this test dir is explicitly deleted on successful runs; retained for diagnostics when
@@ -543,7 +541,8 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     assert(jobcount === getNumJobs("/jobs"))
 
     // no need to retain the test dir now the tests complete
-    logDir.deleteOnExit();
+    logDir.deleteOnExit()
+    quit()
 
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets
 import java.util.zip.ZipInputStream
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
@@ -35,9 +34,8 @@ import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods
 import org.json4s.jackson.JsonMethods._
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.WebDriver
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
-import org.openqa.selenium.support.ui.{ExpectedCondition, WebDriverWait}
 import org.scalatest.{BeforeAndAfter, Matchers}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mock.MockitoSugar
@@ -328,13 +326,18 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
 
       go to s"$url$uiRoot"
 
-      val rows: List[WebElement] = new WebDriverWait(webDriver, 25).until(
-        new ExpectedCondition[List[WebElement]] {
-          override def apply(d: WebDriver) = d.findElements(By.className("odd")).asScala.toList
-        })
+      // expect the ajax call to finish in 5 seconds
+      implicitlyWait(org.scalatest.time.Span(5, org.scalatest.time.Seconds))
 
-      val links = rows.map(_.findElement(By.tagName("a")).getAttribute("href"))
-      
+      // once this findAll call returns, we know the ajax load of the table completed
+      findAll(ClassNameQuery("odd"))
+
+      val links = findAll(TagNameQuery("a"))
+        .map(_.attribute("href"))
+        .filter(_.isDefined)
+        .map(_.get)
+        .filter(_.startsWith(url)).toList
+
       // there are atleast some URL links that were generated via javascript,
       // and they all contain the spark.ui.proxyBase (uiRoot)
       links.length should be > 4

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -35,7 +35,7 @@ import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods
 import org.json4s.jackson.JsonMethods._
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.scalatest.{BeforeAndAfter, Matchers}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mock.MockitoSugar
@@ -317,7 +317,9 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     contextHandler.addServlet(holder, "/")
     server.attachHandler(contextHandler)
 
-    implicit val webDriver: WebDriver = new ChromeDriver
+    implicit val webDriver: WebDriver = new HtmlUnitDriver(true) {
+      getWebClient.getOptions.setThrowExceptionOnScriptError(false)
+    }
 
     try {
       val url = s"http://localhost:$port"
@@ -349,7 +351,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
 
   test("incomplete apps get refreshed") {
 
-    implicit val webDriver: WebDriver = new ChromeDriver
+    implicit val webDriver: WebDriver = new HtmlUnitDriver
     implicit val formats = org.json4s.DefaultFormats
 
     // this test dir is explicitly deleted on successful runs; retained for diagnostics when
@@ -541,8 +543,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     assert(jobcount === getNumJobs("/jobs"))
 
     // no need to retain the test dir now the tests complete
-    logDir.deleteOnExit()
-    quit()
+    logDir.deleteOnExit();
 
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,7 @@
     <antlr4.version>4.5.3</antlr4.version>
     <jpam.version>1.1</jpam.version>
     <selenium.version>2.52.0</selenium.version>
+    <selenium.htmlunitdriver.version>2.27</selenium.htmlunitdriver.version>
     <paranamer.version>2.8</paranamer.version>
     <maven-antrun.version>1.8</maven-antrun.version>
     <commons-crypto.version>1.0.0</commons-crypto.version>
@@ -466,8 +467,8 @@
       </dependency>
       <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
-        <artifactId>selenium-htmlunit-driver</artifactId>
-        <version>${selenium.version}</version>
+        <artifactId>htmlunit-driver</artifactId>
+        <version>${selenium.htmlunitdriver.version}</version>
         <scope>test</scope>
       </dependency>
       <!-- Added for selenium only, and should match its dependent version: -->

--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>selenium-htmlunit-driver</artifactId>
+      <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/streaming/pom.xml
+++ b/streaming/pom.xml
@@ -109,7 +109,7 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>selenium-htmlunit-driver</artifactId>
+      <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
…river

Latest UI fix renders the tests unstable as they rely on the elements being attached in the DOM immediately.  Increasing a Selenium timeout would be a non-option because it would apply to all waiting and it would make builds much slower.  The real fix is be to eliminate the use of HtmlUnit driver which is old and is meant for the ancient days of server-side rendering.