### PR TITLE
Further performance improvements for History UI

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
@@ -29,11 +29,13 @@
           App Name
         </span>
       </th>
+      {{#hasMultipleAttempts}}
       <th class="attemptIDSpan">
         <span data-toggle="tooltip" data-placement="above" title="The attempt ID of this application since one application might be launched several times">
           Attempt ID
         </span>
       </th>
+      {{/hasMultipleAttempts}}
       <th>
         <span data-toggle="tooltip" data-placement="right" title="Started time of this application.">
           Started
@@ -68,10 +70,12 @@
   <tbody>
   {{#applications}}
     <tr>
-      <td class="rowGroupColumn"><span title="{{id}}"><a href="{{uiroot}}/history/{{id}}/{{num}}/jobs/">{{id}}</a></span></td>
-      <td class="rowGroupColumn">{{name}}</td>
+      <td {{#hasMultipleAttempts}}style="background-color:#fff"{{/hasMultipleAttempts}}><span title="{{id}}"><a href="{{uiroot}}/history/{{id}}/{{num}}/jobs/">{{id}}</a></span></td>
+      <td {{#hasMultipleAttempts}}style="background-color:#fff"{{/hasMultipleAttempts}}>{{name}}</td>
       {{#attempts}}
-      <td class="attemptIDSpan"><a href="{{uiroot}}/history/{{id}}/{{attemptId}}/jobs/">{{attemptId}}</a></td>
+      {{#hasMultipleAttempts}}
+      <td><a href="{{uiroot}}/history/{{id}}/{{attemptId}}/jobs/">{{attemptId}}</a></td>
+      {{/hasMultipleAttempts}}
       <td>{{startTime}}</td>
       <td>{{endTime}}</td>
       <td>{{duration}}</td>

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -119,63 +119,47 @@ $(document).ready(function() {
           array.push(app_clone);
         }
       }
+      if(array.length < 20) {
+        $.fn.dataTable.defaults.paging = false;
+      }
 
       var data = {
         "uiroot": uiRoot,
-        "applications": array
-        }
-
+        "applications": array,
+        "hasMultipleAttempts" : hasMultipleAttempts,
+      }
       $.get("static/historypage-template.html", function(template) {
-        var apps = $(Mustache.render($(template).filter("#history-summary-template").html(),data));
-        var selector = "#history-summary-table";
+        var sibling = historySummary.prev();
+        historySummary.detach();
+        historySummary.append(Mustache.render($(template).filter("#history-summary-template").html(),data));
         var conf = {
-                    "columns": [
-                        {name: 'first', type: "appid-numeric"},
-                        {name: 'second'},
-                        {name: 'third'},
-                        {name: 'fourth'},
-                        {name: 'fifth'},
-                        {name: 'sixth', type: "title-numeric"},
-                        {name: 'seventh'},
-                        {name: 'eighth'},
-                        {name: 'ninth'},
-                    ],
-                    "columnDefs": [
-                        {"searchable": false, "targets": [5]}
-                    ],
-                    "autoWidth": false,
-                    "order": [[ 4, "desc" ]]
+          "columns": [
+              {name: 'first', type: "appid-numeric"},
+              {name: 'second'},
+              {name: 'third'},
+              {name: 'fourth'},
+              {name: 'fifth'},
+              {name: 'sixth', type: "title-numeric"},
+              {name: 'seventh'},
+              {name: 'eighth'},
+              {name: 'ninth'},
+          ],
+          "columnDefs": [
+              {"searchable": false, "targets": [5]}
+          ],
+          "autoWidth": false,
+          "order": [[ hasMultipleAttempts? 4 : 3, "desc" ]],                    
+          "rowsGroup": hasMultipleAttempts? [
+            'first:name',
+            'second:name'
+          ] : undefined,
         };
-
-        var rowGroupConf = {
-                           "rowsGroup": [
-                               'first:name',
-                               'second:name'
-                           ],
-        };
-
-        if (hasMultipleAttempts) {
-          jQuery.extend(conf, rowGroupConf);
-          var rowGroupCells = apps.find(".rowGroupColumn");
-          for (i = 0; i < rowGroupCells.length; i++) {
-            rowGroupCells[i].style='background-color: #ffffff';
-          }
-        }
 
         if (!hasMultipleAttempts) {
-          var attemptIDCells = apps.find(".attemptIDSpan");
-          for (i = 0; i < attemptIDCells.length; i++) {
-            attemptIDCells[i].style.display='none';
-          }
+          conf.columns.splice(2, 1);
         }
-
-        historySummary.append(apps);
-
-        if ($(selector.concat(" tr")).length < 20) {
-          $.extend(conf, {paging: false});
-        }
-
-        $(selector).DataTable(conf);
+        historySummary.find("#history-summary-table").DataTable(conf);
+        sibling.after(historySummary);
         $('#hisotry-summary [data-toggle="tooltip"]').tooltip();
       });
     });


### PR DESCRIPTION
Detaching history table wrapper from document before parsing it with DataTables plugin
and reattaching back right after plugin has processed nested DOM. This allows to avoid
huge amount of browser repaints and reflows, reducing initial page load time in Chrome
from 15s to 4s for 20k+ rows.

Further optimizations include moving all table's DOM processing to mustache template:
 - attmptId column
 - background color for first 2 columns
This allows to save additional ~500ms since we're iterating through all rows only once
(instead of 3 times)

Last change in this commit is about removing paging navigation if the number of rows
is < 20. Which was done in O(n) by iterating over list of all <tr> and is now replaced
by checking length of array before passing it to mustache.
