### PR TITLE
[WebUI] Fixing duration column sorting in history UI table

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
@@ -78,7 +78,7 @@
       {{/hasMultipleAttempts}}
       <td>{{startTime}}</td>
       <td>{{endTime}}</td>
-      <td>{{duration}}</td>
+      <td><span title="{{durationMillisec}}">{{duration}}</span></td>
       <td>{{sparkUser}}</td>
       <td>{{lastUpdated}}</td>
       <td><a href="{{uiroot}}/api/v1/applications/{{id}}/{{num}}/logs" class="btn btn-info btn-mini">Download</a></td>

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -114,6 +114,7 @@ $(document).ready(function() {
           attempt["startTime"] = formatDate(attempt["startTime"]);
           attempt["endTime"] = formatDate(attempt["endTime"]);
           attempt["lastUpdated"] = formatDate(attempt["lastUpdated"]);
+          attempt["durationMillisec"] = attempt["duration"];
           attempt["duration"] = formatDuration(attempt["duration"]);
           var app_clone = {"id" : id, "name" : name, "num" : num, "attempts" : [attempt]};
           array.push(app_clone);


### PR DESCRIPTION
Duration column sorting is handled by `title-numeric-pre` filter which
expects any tag inside <td> to have `title` attribute with numeric value.
Which currenlty is empty so DataTables plugin falls back to string comparison.

Here we're wrapping formated duration value (12min, 4h...) in <span> and
populatng `title` with milliseconds value, enabling sorting by `title-numeric-pre`
to work correctly.