### PR TITLE
Add spark-test-tags to mesos module

### DIFF
--- a/mesos/pom.xml
+++ b/mesos/pom.xml
@@ -66,6 +66,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-test-tags_${scala.binary.version}</artifactId>
+    </dependency>
 
     <!-- Explicitly depend on shaded dependencies from the parent, since shaded deps aren't transitive -->
     <dependency>


### PR DESCRIPTION
To be able to pass -Dtest.exclude.tags=org.apache.spark.tags.DockerTest during build tests