### PR TITLE
Rename spark-test-tags to spark-tags

### DIFF
--- a/mesos/pom.xml
+++ b/mesos/pom.xml
@@ -69,7 +69,7 @@
     
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-test-tags_${scala.binary.version}</artifactId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
     </dependency>
 
     <!-- Explicitly depend on shaded dependencies from the parent, since shaded deps aren't transitive -->


### PR DESCRIPTION
To be able to pass -Dtest.exclude.tags=org.apache.spark.tags.DockerTest during build tests