### PR TITLE
Fix scope for spark-tags

### DIFF
--- a/mesos/pom.xml
+++ b/mesos/pom.xml
@@ -70,6 +70,8 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-tags_${scala.binary.version}</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
 
     <!-- Explicitly depend on shaded dependencies from the parent, since shaded deps aren't transitive -->


### PR DESCRIPTION
To be able to pass -Dtest.exclude.tags=org.apache.spark.tags.DockerTest during build tests.
The current setup works only for older versions (1.6)