### PR TITLE
Make chunk size configurable

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/SerializerManager.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/SerializerManager.scala
@@ -70,6 +70,8 @@ private[spark] class SerializerManager(
   private[this] val compressRdds = conf.getBoolean("spark.rdd.compress", false)
   // Whether to compress shuffle output temporarily spilled to disk
   private[this] val compressShuffleSpill = conf.getBoolean("spark.shuffle.spill.compress", true)
+  // Size of the chunks to be used in the ChunkedByteBuffer
+  private[this] val chunkSizeMb = conf.getSizeAsMb("spark.memory.chunkSize", "4").toInt
 
   /* The compression codec to use. Note that the "lazy" val is necessary because we want to delay
    * the initialization of the compression codec until it is first used. The reason is that a Spark
@@ -186,8 +188,7 @@ private[spark] class SerializerManager(
       blockId: BlockId,
       values: Iterator[_],
       classTag: ClassTag[_]): ChunkedByteBuffer = {
-    val size = conf.getSizeAsMb("spark.memory.chunkSize", "4").toInt
-    val bbos = new ChunkedByteBufferOutputStream(1024 * 1024 * size, ByteBuffer.allocate)
+    val bbos = new ChunkedByteBufferOutputStream(1024 * 1024 * chunkSizeMb, ByteBuffer.allocate)
     val byteStream = new BufferedOutputStream(bbos)
     val autoPick = !blockId.isInstanceOf[StreamBlockId]
     val ser = getSerializer(classTag, autoPick).newInstance()

--- a/core/src/main/scala/org/apache/spark/serializer/SerializerManager.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/SerializerManager.scala
@@ -186,7 +186,8 @@ private[spark] class SerializerManager(
       blockId: BlockId,
       values: Iterator[_],
       classTag: ClassTag[_]): ChunkedByteBuffer = {
-    val bbos = new ChunkedByteBufferOutputStream(1024 * 1024 * 4, ByteBuffer.allocate)
+    val size = conf.getSizeAsMb("spark.memory.chunkSize", "4").toInt
+    val bbos = new ChunkedByteBufferOutputStream(1024 * 1024 * size, ByteBuffer.allocate)
     val byteStream = new BufferedOutputStream(bbos)
     val autoPick = !blockId.isInstanceOf[StreamBlockId]
     val ser = getSerializer(classTag, autoPick).newInstance()


### PR DESCRIPTION
Add an option in Spark configuration to change the chunk size (which is by default 4 Mb).

This would allow to bypass the issue mentionned in [SPARK-24917](https://issues.apache.org/jira/browse/SPARK-24917) when fetching large partitions (a bit less than 2 Gb)

P.S. The two commits should be merged in one