### PR TITLE
Add support for disk and network_bandwidth resources to run in Mesos at Criteo

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -657,6 +657,15 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
+  <td><code>spark.mesos.networkBandwidth</code></td>
+  <td><code>0</code></td>
+  <td>
+    Set the amount of network bandwidth to acquire for this job. If not provided, Mesos will allocate a default amount of network bandwidth
+    computed from the number of CPUs allocated to the executor. It's better to always specify an amount otherwise some resources accepted
+    by Spark might be rejected later by Mesos since no matching can be done against network bandwidth.
+  </td>
+</tr>
+<tr>
   <td><code>spark.mesos.network.name</code></td>
   <td><code>(none)</code></td>
   <td>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -646,7 +646,16 @@ See the [configuration page](configuration.html) for information on Spark config
     Set the maximum number GPU resources to acquire for this job. Note that executors will still launch when no GPU resources are found
     since this configuration is just a upper limit and not a guaranteed amount.
   </td>
-  </tr>
+</tr>
+<tr>
+  <td><code>spark.mesos.disk</code></td>
+  <td><code>0</code></td>
+  <td>
+    Set the amount of disk to acquire for this job. You might need to set this value depending on the type of disk isolation set up in Mesos.
+    For instance, setting an amount of disk is required when XFS isolator is enabled with hard limit enforced otherwise the isolator will kill
+    the Mesos executor when downloading the Spark executor archive.
+  </td>
+</tr>
 <tr>
   <td><code>spark.mesos.network.name</code></td>
   <td><code>(none)</code></td>

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -265,8 +265,8 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
       Utils.createTextAttribute("c2", "b"))
     val offers = List(
       Utils.createOffer("o1", "s1", mem, cpu, None, 0),
-      Utils.createOffer("o2", "s2", mem, cpu, None, 0, s2Attributes),
-      Utils.createOffer("o3", "s3", mem, cpu, None, 0, s3Attributes))
+      Utils.createOffer("o2", "s2", mem, cpu, None, 0, 0, s2Attributes),
+      Utils.createOffer("o3", "s3", mem, cpu, None, 0, 0, s3Attributes))
 
     def submitDriver(driverConstraints: String): Unit = {
       val response = scheduler.submitDriver(

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterSchedulerSuite.scala
@@ -265,8 +265,8 @@ class MesosClusterSchedulerSuite extends SparkFunSuite with LocalSparkContext wi
       Utils.createTextAttribute("c2", "b"))
     val offers = List(
       Utils.createOffer("o1", "s1", mem, cpu, None, 0),
-      Utils.createOffer("o2", "s2", mem, cpu, None, 0, 0, s2Attributes),
-      Utils.createOffer("o3", "s3", mem, cpu, None, 0, 0, s3Attributes))
+      Utils.createOffer("o2", "s2", mem, cpu, None, 0, 0, 0, s2Attributes),
+      Utils.createOffer("o3", "s3", mem, cpu, None, 0, 0, 0, s3Attributes))
 
     def submitDriver(driverConstraints: String): Unit = {
       val response = scheduler.submitDriver(

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosCoarseGrainedSchedulerBackendSuite.scala
@@ -137,6 +137,46 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     assert(cpus == offerCores)
   }
 
+  test("mesos supports spark.mesos.disk") {
+    val claimedDisk = 40
+    setBackend(Map("spark.mesos.disk" -> claimedDisk.toString))
+
+    val executorMemory = backend.executorMemory(sc)
+    val offers = List(Resources(executorMemory, 1, 0, 100))
+    offerResources(offers)
+
+    val taskInfos = verifyTaskLaunched(driver, "o1")
+    assert(taskInfos.length == 1)
+
+    val taskDisk = backend.getResource(taskInfos.head.getResourcesList, "disk")
+    assert(taskDisk == claimedDisk)
+  }
+
+  test("mesos supports unset spark.mesos.disk") {
+    setBackend()
+
+    val executorMemory = backend.executorMemory(sc)
+    val offers = List(Resources(executorMemory, 1, 0, 100))
+    offerResources(offers)
+
+    val taskInfos = verifyTaskLaunched(driver, "o1")
+    assert(taskInfos.length == 1)
+
+    val taskDisk = backend.getResource(taskInfos.head.getResourcesList, "disk")
+    assert(taskDisk == 0)
+  }
+
+  test("mesos declines offer if not enough disk available") {
+    val claimedDisk = 400
+    setBackend(Map("spark.mesos.disk" -> claimedDisk.toString))
+
+    val executorMemory = backend.executorMemory(sc)
+    val offers = List(Resources(executorMemory, 1, 0, 100))
+    offerResources(offers)
+
+    verifyDeclinedOffer(driver, createOfferId("o1"))
+  }
+
   test("mesos does not acquire more than spark.cores.max") {
     val maxCores = 10
     setBackend(Map("spark.cores.max" -> maxCores.toString))
@@ -683,7 +723,7 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
     verifyTaskLaunched(driver, "o1")
   }
 
-  private case class Resources(mem: Int, cpus: Int, gpus: Int = 0)
+  private case class Resources(mem: Int, cpus: Int, gpus: Int = 0, disk: Int = 0)
 
   private def registerMockExecutor(executorId: String, slaveId: String, cores: Integer) = {
     val mockEndpointRef = mock[RpcEndpointRef]
@@ -705,7 +745,8 @@ class MesosCoarseGrainedSchedulerBackendSuite extends SparkFunSuite
 
   private def offerResources(offers: List[Resources], startId: Int = 1): Unit = {
     val mesosOffers = offers.zipWithIndex.map {case (offer, i) =>
-      createOffer(s"o${i + startId}", s"s${i + startId}", offer.mem, offer.cpus, None, offer.gpus)}
+      createOffer(s"o${i + startId}", s"s${i + startId}", offer.mem, offer.cpus, None, offer.gpus,
+        offer.disk)}
 
     backend.resourceOffers(driver, mesosOffers.asJava)
   }

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
@@ -49,6 +49,7 @@ object Utils {
                    cpus: Int,
                    ports: Option[(Long, Long)] = None,
                    gpus: Int = 0,
+                   disk: Int = 0,
                    attributes: List[Attribute] = List.empty): Offer = {
     val builder = Offer.newBuilder()
     builder.addResourcesBuilder()
@@ -71,6 +72,12 @@ object Utils {
         .setName("gpus")
         .setType(Value.Type.SCALAR)
         .setScalar(Scalar.newBuilder().setValue(gpus))
+    }
+    if (disk > 0) {
+      builder.addResourcesBuilder()
+        .setName("disk")
+        .setType(Value.Type.SCALAR)
+        .setScalar(Scalar.newBuilder().setValue(disk))
     }
     builder.setId(createOfferId(offerId))
       .setFrameworkId(FrameworkID.newBuilder()

--- a/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
+++ b/resource-managers/mesos/src/test/scala/org/apache/spark/scheduler/cluster/mesos/Utils.scala
@@ -50,6 +50,7 @@ object Utils {
                    ports: Option[(Long, Long)] = None,
                    gpus: Int = 0,
                    disk: Int = 0,
+                   networkBandwidth: Int = 0,
                    attributes: List[Attribute] = List.empty): Offer = {
     val builder = Offer.newBuilder()
     builder.addResourcesBuilder()
@@ -78,6 +79,12 @@ object Utils {
         .setName("disk")
         .setType(Value.Type.SCALAR)
         .setScalar(Scalar.newBuilder().setValue(disk))
+    }
+    if (networkBandwidth > 0) {
+      builder.addResourcesBuilder()
+        .setName("network_bandwidth")
+        .setType(Value.Type.SCALAR)
+        .setScalar(Scalar.newBuilder().setValue(networkBandwidth))
     }
     builder.setId(createOfferId(offerId))
       .setFrameworkId(FrameworkID.newBuilder()


### PR DESCRIPTION
This PR is made of 2 patches:
1. Support for disk resource that is required to run Spark on Mesos at Criteo since we enabled the XFS isolator that requires that any container should have disk reserved.
2. Support for network bandwidth, otherwise Mesos will allocate a default amount based on the number of CPU. The user should be able to customize in order for the executor not to be killed by Mesos if the limit is exceeded and packets are dropped too abruptly.

Fix 1. is a backport in Spark 2.3 from a PR in 3.0 (https://github.com/apache/spark/pull/23758)
Fix 2. is completely Criteo specific since it relies on a resource that we introduced ourselves.