### PR TITLE
Lower log level when response cannot be sent to client

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
@@ -289,7 +289,7 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
       if (future.isSuccess()) {
         logger.trace("Sent result {} to client {}", result, remoteAddress);
       } else {
-        logger.error(String.format("Error sending result %s to %s; closing connection",
+        logger.warn(String.format("Error sending result %s to %s; closing connection",
           result, remoteAddress), future.cause());
         channel.close();
       }


### PR DESCRIPTION
To avoid blocking the service when several connections are lost with already enqueued responses
