### PR TITLE
Backport of SPARK-27586: Imrove binary comparison

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
@@ -65,11 +65,12 @@ object TypeUtils {
   }
 
   def compareBinary(x: Array[Byte], y: Array[Byte]): Int = {
-    for (i <- 0 until x.length; if i < y.length) {
-      val v1 = x(i) & 0xff
-      val v2 = y(i) & 0xff
-      val res = v1 - v2
+    val limit = if (x.length <= y.length) x.length else y.length
+    var i = 0
+    while (i < limit) {
+      val res = (x(i) & 0xff) - (y(i) & 0xff)
       if (res != 0) return res
+      i += 1
     }
     x.length - y.length
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TypeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TypeUtilsSuite.scala
@@ -43,4 +43,22 @@ class TypeUtilsSuite extends SparkFunSuite {
     typeCheckPass(ArrayType(StringType, containsNull = true) ::
       ArrayType(StringType, containsNull = false) :: Nil)
   }
+
+  test("compareBinary") {
+    val x1 = Array[Byte]()
+    val y1 = Array(1, 2, 3).map(_.toByte)
+    assert(TypeUtils.compareBinary(x1, y1) < 0)
+
+    val x2 = Array(200, 100).map(_.toByte)
+    val y2 = Array(100, 100).map(_.toByte)
+    assert(TypeUtils.compareBinary(x2, y2) > 0)
+
+    val x3 = Array(100, 200, 12).map(_.toByte)
+    val y3 = Array(100, 200).map(_.toByte)
+    assert(TypeUtils.compareBinary(x3, y3) > 0)
+
+    val x4 = Array(100, 200).map(_.toByte)
+    val y4 = Array(100, 200).map(_.toByte)
+    assert(TypeUtils.compareBinary(x4, y4) == 0)
+  }
 }


### PR DESCRIPTION
Original commit: 3859ca37d9b20ec130d386254d86fbd353486fde

Improve binary comparison: replace Scala's for-comprehension if statements with while loop

This PR replaces for-comprehension if statement with while loop to gain better performance in `TypeUtils.compareBinary`.

Add UT to test old version and new version comparison result

Closes #24494 from woudygao/opt_binary_compare.

Authored-by: gaoweikang <gaoweikang@bytedance.com>
Signed-off-by: Dongjoon Hyun <dhyun@apple.com>