### PR TITLE
Revert "Use Criteo's internal Parquet fork"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <!-- Version used for internal directory structure -->
     <hive.version.short>1.2.1</hive.version.short>
     <derby.version>10.12.1.1</derby.version>
-    <parquet.version>1.9.1+20200901095416</parquet.version>
+    <parquet.version>1.8.3</parquet.version>
     <orc.version>1.4.4</orc.version>
     <orc.classifier>nohive</orc.classifier>
     <hive.parquet.version>1.6.0</hive.parquet.version>


### PR DESCRIPTION
Reverts criteo-forks/spark#102