### PR TITLE
Dynamic allocation: optionally ignore task locality to request new executors

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -94,6 +94,9 @@ private[spark] class ExecutorAllocationManager(
 
   import ExecutorAllocationManager._
 
+  // If True then executors will be requested without locality hints
+  private val ignoreTaskLocality = conf.get(DYN_ALLOCATION_IGNORE_TASK_LOCALITY)
+
   // Lower and upper bounds on the number of executors.
   private val minNumExecutors = conf.get(DYN_ALLOCATION_MIN_EXECUTORS)
   private val maxNumExecutors = conf.get(DYN_ALLOCATION_MAX_EXECUTORS)
@@ -684,7 +687,9 @@ private[spark] class ExecutorAllocationManager(
           (numTasksPending, hostToLocalTaskCountPerStage.toMap))
 
         // Update the executor placement hints
-        updateExecutorPlacementHints()
+        if (!allocationManager.ignoreTaskLocality) {
+          updateExecutorPlacementHints()
+        }
       }
     }
 
@@ -699,7 +704,9 @@ private[spark] class ExecutorAllocationManager(
         stageIdToExecutorPlacementHints -= stageId
 
         // Update the executor placement hints
-        updateExecutorPlacementHints()
+        if (!allocationManager.ignoreTaskLocality) {
+          updateExecutorPlacementHints()
+        }
 
         // If this is the last stage with pending tasks, mark the scheduler queue as empty
         // This is needed in case the stage is aborted for any reason

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -129,6 +129,9 @@ package object config {
 
   private[spark] val CPUS_PER_TASK = ConfigBuilder("spark.task.cpus").intConf.createWithDefault(1)
 
+  private[spark] val DYN_ALLOCATION_IGNORE_TASK_LOCALITY =
+    ConfigBuilder("spark.dynamicAllocation.ignoreTaskLocality").booleanConf.createWithDefault(false)
+
   private[spark] val DYN_ALLOCATION_MIN_EXECUTORS =
     ConfigBuilder("spark.dynamicAllocation.minExecutors").intConf.createWithDefault(0)
 

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -976,6 +976,39 @@ class ExecutorAllocationManagerSuite
       Map("host2" -> 1, "host3" -> 2, "host4" -> 1, "host5" -> 2))
   }
 
+  test("Ignore locality preference") {
+    sc = createSparkContext(2, 5, 3, true)
+    val manager = sc.executorAllocationManager.get
+
+    val localityPreferences1 = Seq(
+      Seq(TaskLocation("host1"), TaskLocation("host2"), TaskLocation("host3")),
+      Seq(TaskLocation("host1"), TaskLocation("host2"), TaskLocation("host4")),
+      Seq(TaskLocation("host2"), TaskLocation("host3"), TaskLocation("host4")),
+      Seq.empty,
+      Seq.empty
+    )
+    val stageInfo1 = createStageInfo(1, 5, localityPreferences1)
+    post(sc.listenerBus, SparkListenerStageSubmitted(stageInfo1))
+
+    assert(localityAwareTasks(manager) === 0)
+    assert(hostToLocalTaskCount(manager) === Map.empty)
+
+    val localityPreferences2 = Seq(
+      Seq(TaskLocation("host2"), TaskLocation("host3"), TaskLocation("host5")),
+      Seq(TaskLocation("host3"), TaskLocation("host4"), TaskLocation("host5")),
+      Seq.empty
+    )
+    val stageInfo2 = createStageInfo(2, 3, localityPreferences2)
+    post(sc.listenerBus, SparkListenerStageSubmitted(stageInfo2))
+
+    assert(localityAwareTasks(manager) === 0)
+    assert(hostToLocalTaskCount(manager) === Map.empty)
+
+    post(sc.listenerBus, SparkListenerStageCompleted(stageInfo1))
+    assert(localityAwareTasks(manager) === 0)
+    assert(hostToLocalTaskCount(manager) === Map.empty)
+  }
+
   test("SPARK-8366: maxNumExecutorsNeeded should properly handle failed tasks") {
     sc = createSparkContext()
     val manager = sc.executorAllocationManager.get
@@ -1188,7 +1221,8 @@ class ExecutorAllocationManagerSuite
   private def createSparkContext(
       minExecutors: Int = 1,
       maxExecutors: Int = 5,
-      initialExecutors: Int = 1): SparkContext = {
+      initialExecutors: Int = 1,
+      ignoreTaskLocality: Boolean = false): SparkContext = {
     val conf = new SparkConf()
       .setMaster("myDummyLocalExternalClusterManager")
       .setAppName("test-executor-allocation-manager")
@@ -1205,6 +1239,7 @@ class ExecutorAllocationManagerSuite
       // SPARK-22864: effectively disable the allocation schedule by setting the period to a
       // really long value.
       .set(TESTING_SCHEDULE_INTERVAL_KEY, "10000")
+      .set("spark.dynamicAllocation.ignoreTaskLocality", ignoreTaskLocality.toString)
     val sc = new SparkContext(conf)
     contexts += sc
     sc


### PR DESCRIPTION
Hi there!
When activating the dynamic allocation for one of our jobs, we figured out that executors acquired via dynamic allocation used less cpu than executors acquired via static allocation. It turns out that Spark requests new executors with locality hints. In result, executors are much more colocated than in the static allocation scenario. In our case, the job is cpu-intensive and the processing time is >> data transfert. In such a case, we would prefer spreading executors on different machines that having them colocated to limit resource interferences between tasks.
This PR aims at optionally ignoring task locality in the dynamic allocation manager.