### PR TITLE
Dynamic allocation: optionally ignore task locality to request new ex…

### DIFF
--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java
@@ -18,7 +18,6 @@
 package org.apache.spark.network.yarn;
 
 import com.codahale.metrics.*;
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
@@ -52,7 +51,8 @@ public class YarnShuffleServiceMetrics implements MetricsSource {
     }
   }
 
-  public static void collectMetric(MetricsRecordBuilder metricsRecordBuilder, String name, Metric metric) {
+  public static void collectMetric(
+    MetricsRecordBuilder metricsRecordBuilder, String name, Metric metric) {
 
     // The metric types used in ExternalShuffleBlockHandler.ShuffleMetrics
     if (metric instanceof Timer) {

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -26,7 +26,7 @@ import scala.util.control.{ControlThrowable, NonFatal}
 import com.codahale.metrics.{Gauge, MetricRegistry}
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.{DYN_ALLOCATION_MAX_EXECUTORS, DYN_ALLOCATION_MIN_EXECUTORS, DYN_ALLOCATION_IGNORE_TASK_LOCALITY}
+import org.apache.spark.internal.config.{DYN_ALLOCATION_IGNORE_TASK_LOCALITY, DYN_ALLOCATION_MAX_EXECUTORS, DYN_ALLOCATION_MIN_EXECUTORS}
 import org.apache.spark.metrics.source.Source
 import org.apache.spark.scheduler._
 import org.apache.spark.storage.BlockManagerMaster

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -26,7 +26,7 @@ import scala.util.control.{ControlThrowable, NonFatal}
 import com.codahale.metrics.{Gauge, MetricRegistry}
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.{DYN_ALLOCATION_MAX_EXECUTORS, DYN_ALLOCATION_MIN_EXECUTORS}
+import org.apache.spark.internal.config.{DYN_ALLOCATION_MAX_EXECUTORS, DYN_ALLOCATION_MIN_EXECUTORS, DYN_ALLOCATION_IGNORE_TASK_LOCALITY}
 import org.apache.spark.metrics.source.Source
 import org.apache.spark.scheduler._
 import org.apache.spark.storage.BlockManagerMaster

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -90,6 +90,9 @@ private[spark] class ExecutorAllocationManager(
 
   import ExecutorAllocationManager._
 
+  // If True then executors will be requested without locality hints
+  private val ignoreTaskLocality = conf.get(DYN_ALLOCATION_IGNORE_TASK_LOCALITY)
+
   // Lower and upper bounds on the number of executors.
   private val minNumExecutors = conf.get(DYN_ALLOCATION_MIN_EXECUTORS)
   private val maxNumExecutors = conf.get(DYN_ALLOCATION_MAX_EXECUTORS)
@@ -668,7 +671,9 @@ private[spark] class ExecutorAllocationManager(
           (numTasksPending, hostToLocalTaskCountPerStage.toMap))
 
         // Update the executor placement hints
-        updateExecutorPlacementHints()
+        if (!allocationManager.ignoreTaskLocality) {
+           updateExecutorPlacementHints()
+        }
       }
     }
 
@@ -683,7 +688,9 @@ private[spark] class ExecutorAllocationManager(
         stageIdToExecutorPlacementHints -= stageId
 
         // Update the executor placement hints
-        updateExecutorPlacementHints()
+        if (!allocationManager.ignoreTaskLocality) {
+           updateExecutorPlacementHints()
+        }
 
         // If this is the last stage with pending tasks, mark the scheduler queue as empty
         // This is needed in case the stage is aborted for any reason

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -116,6 +116,9 @@ package object config {
 
   private[spark] val CPUS_PER_TASK = ConfigBuilder("spark.task.cpus").intConf.createWithDefault(1)
 
+  private[spark] val DYN_ALLOCATION_IGNORE_TASK_LOCALITY =
+     ConfigBuilder("spark.dynamicAllocation.ignoreTaskLocality").booleanConf.createWithDefault(false)
+
   private[spark] val DYN_ALLOCATION_MIN_EXECUTORS =
     ConfigBuilder("spark.dynamicAllocation.minExecutors").intConf.createWithDefault(0)
 


### PR DESCRIPTION
Hi there!
When activating the dynamic allocation for one of our jobs, we figured out that executors acquired via dynamic allocation used less cpu than executors acquired via static allocation. It turns out that Spark requests new executors with locality hints. In result, executors are much more colocated than in the static allocation scenario. In our case, the job is cpu-intensive and the processing time is >> data transfert. In such a case, we would prefer spreading executors on different machines that having them colocated to limit resource interferences between tasks.
This PR aims at optionally ignoring task locality in the dynamic allocation manager.