### PR TITLE
Fix wrong intendation that is causing scalastyle check to fail

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -117,7 +117,7 @@ package object config {
   private[spark] val CPUS_PER_TASK = ConfigBuilder("spark.task.cpus").intConf.createWithDefault(1)
 
   private[spark] val DYN_ALLOCATION_IGNORE_TASK_LOCALITY =
-     ConfigBuilder("spark.dynamicAllocation.ignoreTaskLocality").booleanConf.createWithDefault(false)
+    ConfigBuilder("spark.dynamicAllocation.ignoreTaskLocality").booleanConf.createWithDefault(false)
 
   private[spark] val DYN_ALLOCATION_MIN_EXECUTORS =
     ConfigBuilder("spark.dynamicAllocation.minExecutors").intConf.createWithDefault(0)


### PR DESCRIPTION
An additional space character caused the line to pass over 100 characters, causing the build job to fail