### PR TITLE
[CRITEO] Fix SHS performance

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -173,7 +173,9 @@ private[history] class ApplicationCache(
       }
     }
     try {
-      val completed = loadedUI.ui.getApplicationInfoList.exists(_.attempts.last.completed)
+      val completed = loadedUI.ui
+        .mapApplicationInfoList(_.find(_.attempts.last.completed).iterator)
+        .nonEmpty
       if (!completed) {
         // incomplete UIs have the cache-check filter put in front of them.
         registerFilter(new CacheKey(appId, attemptId), loadedUI)

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -97,7 +97,7 @@ private[history] abstract class ApplicationHistoryProvider {
    *
    * @return List of all know applications.
    */
-  def getListing(): Iterator[ApplicationInfo]
+  def mapListing[B](mapFunc: Iterator[ApplicationInfo] => Iterator[B]): Seq[B]
 
   /**
    * Returns the Spark UI for a specific application.

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -294,10 +294,10 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     }
   }
 
-  override def getListing(): Iterator[ApplicationInfo] = {
+  override def mapListing[B](mapFunc: Iterator[ApplicationInfo] => Iterator[B]): Seq[B] = {
     // Return the listing in end time descending order.
-    KVUtils.mapToSeq(listing.view(classOf[ApplicationInfoWrapper])
-      .index("endTime").reverse())(_.toApplicationInfo()).iterator
+    KVUtils.mapItToSeq(listing.view(classOf[ApplicationInfoWrapper])
+      .index("endTime").reverse())(it => mapFunc(it.map(_.toApplicationInfo())))
   }
 
   override def getApplicationInfo(appId: String): Option[ApplicationInfo] = {

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -91,7 +91,9 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
   }
 
   def shouldDisplayApplications(requestedIncomplete: Boolean): Boolean = {
-    parent.getApplicationList().exists(isApplicationCompleted(_) != requestedIncomplete)
+    parent
+      .mapApplicationList { _.find(isApplicationCompleted(_) != requestedIncomplete).iterator }
+      .nonEmpty
   }
 
   private def makePageLink(request: HttpServletRequest, showIncomplete: Boolean): String = {

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -204,8 +204,8 @@ class HistoryServer(
    *
    * @return List of all known applications.
    */
-  def getApplicationList(): Iterator[ApplicationInfo] = {
-    provider.getListing()
+  def mapApplicationList[B](mapFunc: Iterator[ApplicationInfo] => Iterator[B]): Seq[B] = {
+    provider.mapListing(mapFunc)
   }
 
   def getEventLogsUnderProcess(): Int = {
@@ -216,8 +216,8 @@ class HistoryServer(
     provider.getLastUpdatedTime()
   }
 
-  def getApplicationInfoList: Iterator[ApplicationInfo] = {
-    getApplicationList()
+  def mapApplicationInfoList[B](mapFunc: Iterator[ApplicationInfo] => Iterator[B]): Seq[B] = {
+    mapApplicationList(mapFunc)
   }
 
   def getApplicationInfo(appId: String): Option[ApplicationInfo] = {

--- a/core/src/main/scala/org/apache/spark/status/KVUtils.scala
+++ b/core/src/main/scala/org/apache/spark/status/KVUtils.scala
@@ -210,6 +210,12 @@ private[spark] object KVUtils extends Logging {
     }
   }
 
+  def mapItToSeq[T, B](view: KVStoreView[T])(mapFunc: Iterator[T] => Iterator[B]): Seq[B] = {
+    Utils.tryWithResource(view.closeableIterator()) { iter =>
+      mapFunc(iter.asScala).toList
+    }
+  }
+
   def size[T](view: KVStoreView[T]): Int = {
     Utils.tryWithResource(view.closeableIterator()) { iter =>
       iter.asScala.size

--- a/core/src/main/scala/org/apache/spark/status/api/v1/ApiRootResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/ApiRootResource.scala
@@ -81,7 +81,7 @@ private[spark] trait UIRoot {
    */
   def withSparkUI[T](appId: String, attemptId: Option[String])(fn: SparkUI => T): T
 
-  def getApplicationInfoList: Iterator[ApplicationInfo]
+  def mapApplicationInfoList[B](mapFunc: Iterator[ApplicationInfo] => Iterator[B]): Seq[B]
   def getApplicationInfo(appId: String): Option[ApplicationInfo]
 
   /**

--- a/core/src/main/scala/org/apache/spark/status/api/v1/ApplicationListResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/ApplicationListResource.scala
@@ -37,7 +37,7 @@ private[v1] class ApplicationListResource extends ApiRequestContext {
     val includeCompleted = status.isEmpty || status.contains(ApplicationStatus.COMPLETED)
     val includeRunning = status.isEmpty || status.contains(ApplicationStatus.RUNNING)
 
-    uiRoot.getApplicationInfoList.filter { app =>
+    uiRoot.mapApplicationInfoList(_.filter { app =>
       val anyRunning = app.attempts.isEmpty || !app.attempts.head.completed
       // if any attempt is still running, we consider the app to also still be running;
       // keep the app if *any* attempts fall in the right time window
@@ -45,7 +45,7 @@ private[v1] class ApplicationListResource extends ApiRequestContext {
       app.attempts.exists { attempt =>
         isAttemptInRange(attempt, minDate, maxDate, minEndDate, maxEndDate, anyRunning)
       }
-    }.take(numApps)
+    }.take(numApps)).iterator
   }
 
   private def isAttemptInRange(

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -171,8 +171,8 @@ private[spark] class SparkUI private (
     securityManager.checkUIViewPermissions(user)
   }
 
-  def getApplicationInfoList: Iterator[ApplicationInfo] = {
-    Iterator(new ApplicationInfo(
+  def mapApplicationInfoList[B](mapFunc: Iterator[ApplicationInfo] => Iterator[B]): Seq[B] = {
+    mapFunc(Iterator(new ApplicationInfo(
       id = appId,
       name = appName,
       coresGranted = None,
@@ -189,11 +189,11 @@ private[spark] class SparkUI private (
         completed = false,
         appSparkVersion = appSparkVersion
       ))
-    ))
+    ))).toSeq
   }
 
   def getApplicationInfo(appId: String): Option[ApplicationInfo] = {
-    getApplicationInfoList.find(_.id == appId)
+    mapApplicationInfoList(_.find(_.id == appId).iterator).headOption
   }
 
   def getStreamingJobProgressListener: Option[SparkListener] = streamingJobProgressListener

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -132,7 +132,7 @@ class ApplicationCacheSuite extends SparkFunSuite with MockitoSugar with Matcher
       Seq(new AttemptInfo(attemptId, new Date(started), new Date(ended),
         new Date(ended), ended - started, "user", completed, org.apache.spark.SPARK_VERSION)))
     val ui = mock[SparkUI]
-    when(ui.getApplicationInfoList).thenReturn(List(info).iterator)
+    when(ui.mapApplicationInfoList[Any](any())).thenReturn(List(info))
     when(ui.getAppName).thenReturn(name)
     when(ui.appName).thenReturn(name)
     val handler = new ServletContextHandler()

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -303,7 +303,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     oldLog.mkdir()
 
     provider.checkForLogs()
-    val appListAfterRename = provider.getListing()
+    val appListAfterRename = provider.mapListing(identity)
     appListAfterRename.size should be (1)
   }
 
@@ -1556,7 +1556,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
       provider.checkForLogs()
       provider.cleanLogs()
       assert(dir.listFiles().size === 1)
-      assert(provider.getListing.length === 1)
+      assert(provider.mapListing(identity).length === 1)
 
       // Manually delete the appstatus file to make an invalid rolling event log
       val appStatusPath = RollingEventLogFilesWriter.getAppStatusFilePath(new Path(writer.logPath),
@@ -1564,7 +1564,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
       fs.delete(appStatusPath, false)
       provider.checkForLogs()
       provider.cleanLogs()
-      assert(provider.getListing.length === 0)
+      assert(provider.mapListing(identity).length === 0)
 
       // Create a new application
       val writer2 = new RollingEventLogFilesWriter("app2", None, dir.toURI, conf, hadoopConf)
@@ -1576,14 +1576,14 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
       // Both folders exist but only one application found
       provider.checkForLogs()
       provider.cleanLogs()
-      assert(provider.getListing.length === 1)
+      assert(provider.mapListing(identity).length === 1)
       assert(dir.listFiles().size === 2)
 
       // Make sure a new provider sees the valid application
       provider.stop()
       val newProvider = new FsHistoryProvider(conf)
       newProvider.checkForLogs()
-      assert(newProvider.getListing.length === 1)
+      assert(newProvider.mapListing(identity).length === 1)
     }
   }
 
@@ -1613,10 +1613,10 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
 
       // The 1st checkForLogs should scan/update app2 only since it is newer than app1
       provider.checkForLogs()
-      assert(provider.getListing.length === 1)
+      assert(provider.mapListing(identity).length === 1)
       assert(dir.listFiles().size === 2)
-      assert(provider.getListing().map(e => e.id).contains("app2"))
-      assert(!provider.getListing().map(e => e.id).contains("app1"))
+      assert(provider.mapListing(e => e.map(_.id)).contains("app2"))
+      assert(!provider.mapListing(e => e.map(_.id)).contains("app1"))
 
       // Create 3rd application
       val writer3 = new RollingEventLogFilesWriter("app3", None, dir.toURI, conf, hadoopConf)
@@ -1628,10 +1628,10 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
 
       // The 2nd checkForLogs should scan/update app3 only since it is newer than app1
       provider.checkForLogs()
-      assert(provider.getListing.length === 2)
+      assert(provider.mapListing(identity).length === 2)
       assert(dir.listFiles().size === 3)
-      assert(provider.getListing().map(e => e.id).contains("app3"))
-      assert(!provider.getListing().map(e => e.id).contains("app1"))
+      assert(provider.mapListing(e => e.map(_.id)).contains("app3"))
+      assert(!provider.mapListing(e => e.map(_.id)).contains("app1"))
 
       provider.stop()
     }
@@ -1655,7 +1655,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
       provider.checkForLogs()
       provider.cleanLogs()
       assert(dir.listFiles().size === 1)
-      assert(provider.getListing.length === 1)
+      assert(provider.mapListing(identity).length === 1)
 
       // Manually delete event log files and create event log file reader
       val eventLogDir = dir.listFiles().head
@@ -1759,7 +1759,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     )
     log3.setLastModified(0L)
 
-    provider.getListing().size should be (0)
+    provider.mapListing(identity).size should be (0)
 
     // Move the clock forward so log1 and log3 exceed the max age.
     clock.advance(maxAge)
@@ -1767,7 +1767,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     provider.checkForLogs()
 
     provider.doMergeApplicationListingCall should be (1)
-    provider.getListing().size should be (1)
+    provider.mapListing(identity).size should be (1)
 
     assert(!log1.exists())
     assert(!log3.exists())
@@ -1786,7 +1786,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
       (checkFn: Seq[ApplicationInfo] => Unit): Unit = {
     provider.checkForLogs()
     provider.cleanLogs()
-    checkFn(provider.getListing().toSeq)
+    checkFn(provider.mapListing(identity))
   }
 
   private def writeFile(file: File, codec: Option[CompressionCodec],

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -541,7 +541,7 @@ abstract class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with
       assert(4 === getNumJobsRestful(), s"two jobs back-to-back not updated, server=$server\n")
     }
     val jobcount = getNumJobs("/jobs")
-    assert(!isApplicationCompleted(provider.getListing().next))
+    assert(!isApplicationCompleted(provider.mapListing(identity).iterator.next))
 
     listApplications(false) should contain(appId)
 
@@ -549,7 +549,7 @@ abstract class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with
     resetSparkContext()
     // check the app is now found as completed
     eventually(stdTimeout, stdInterval) {
-      assert(isApplicationCompleted(provider.getListing().next),
+      assert(isApplicationCompleted(provider.mapListing(identity).iterator.next),
         s"application never completed, server=$server\n")
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
We introduce a new method in KVUtils class to transform directly a KVStoreView iterator within the boundary of the tryWithResource introduced with SPARK-38896. This allows to keep the expected KVStoreIterator recycling, while allowing to compute the minimal information required.


### Why are the changes needed?
SPARK-38896 introduce a huge performance regression. At many places, instead of manipulating an iterator on the database data and stopping eagerly, SHS now constructs an intermediate list of the entire SHS database data and then returns an iterator on it, which causes sever performance degradation.

The performance boost goes from 30s+ to load the main SHS page to less than 2s.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit tests have been corrected to call the new method. The patch is running on a prod environment managing 200k+ spark apps per day.
