### PR TITLE
Fix twine upload to nexus

### DIFF
--- a/external/docker/criteo-build/build_script.sh
+++ b/external/docker/criteo-build/build_script.sh
@@ -28,11 +28,12 @@ deploy_python()
   sed -i "s/__version__ = \\\".*\\\"/__version__ = \\\"${pyspark_version}\\\"/g" python/pyspark/version.py
   python -m venv venv
   source venv/bin/activate
-  pip install --upgrade pip
-  pip install -r python/requirements.txt
+  pip install --quiet --upgrade pip
+  pip install --quiet -r python/requirements.txt
   cd python
+  rm -fr dist/*
   python setup.py bdist_wheel
-  twine upload dist/pyspark*whl -u ${TWINE_USERNAME} -p ${TWINE_PASSWORD} --skip-existing --repository-url "${NEXUS_PYPY_URL}/"
+  twine upload dist/pyspark*whl -u ${TWINE_USERNAME} -p ${TWINE_PASSWORD} --skip-existing --repository-url "${NEXUS_PYPY_URL}"
   python setup.py clean --all
   cd $OLDPWD
 }


### PR DESCRIPTION
We are building 2 pyspark wheel file:
  - One with hadoop
  - One without hadoop

When we upload the second one, the wheel file with Hadoop is still present in the dist directory.
So `twine upload dist/pyspark*whl` will try to upload them all.

Since, the Hadoop wheel file has already been uploaded, it will fail with:
HTTPError: 400 Bad Request

Fix:
- Remove dist directory existing wheel files
- Add quiet option to pip install (cosmetic change)
- Remove the / at the end of nexus PYPI URL (cosmetic change)
