### PR TITLE
build: Uniformize mvn validate with other spark release

### DIFF
--- a/external/docker/criteo-build/build_script.sh
+++ b/external/docker/criteo-build/build_script.sh
@@ -123,7 +123,7 @@ mvn deploy:deploy-file \
     ${MVN_COMMON_DEPLOY_FILE_PROPERTIES}
 
 # jar artifacts (for parent poms) deployment
-mvn deploy \
+mvn validate jar:jar jar:test-jar source:jar-no-fork deploy:deploy \
     --batch-mode \
     ${MVN_COMMON_PROPERTIES} \
     -Phadoop-provided \


### PR DESCRIPTION
For the other spark release, we perform a mvn validate instead of the
mvn deploy.
This release has been forgotten.