### PR TITLE
build: Fix pom.xml and scala sources in build_script.sh

### DIFF
--- a/external/docker/criteo-build/build_script.sh
+++ b/external/docker/criteo-build/build_script.sh
@@ -124,15 +124,30 @@ mvn deploy:deploy-file \
     -Dfile=${SHUFFLE_SERVICE_JAR_FILE} \
     ${MVN_COMMON_DEPLOY_FILE_PROPERTIES}
 
-# jar artifacts (for parent poms) deployment
+# Build and deploy all modules EXCEPT the root-level spark-parent_2.12 module,
+# to avoid generating and uploading unwanted -tests.jar from a POM-only module.
 mvn validate jar:jar jar:test-jar source:jar-no-fork deploy:deploy \
     --batch-mode \
+    -pl "!org.apache.spark:spark-parent_${SCALA_RELEASE}" \
     ${MVN_COMMON_PROPERTIES} \
     -Phadoop-provided \
     -DaltDeploymentRepository=criteo::default::${NEXUS_ARTIFACT_URL} \
     -Dcriteo.repo.username=${MAVEN_USER} \
     -Dcriteo.repo.password=${MAVEN_PASSWORD} \
     -DskipTests
+
+# Deploy the parent POM (at project root) manually, with no JAR generation.
+# This ensures only the .pom file is published, as expected for a parent POM.
+mvn deploy:deploy-file \
+    -DgroupId=org.apache.spark \
+    -DartifactId=spark-parent_${SCALA_RELEASE} \
+    -Dversion=${CRITEO_VERSION} \
+    -Dpackaging=pom \
+    -Dfile=./pom.xml \
+    -DrepositoryId=criteo \
+    -Durl=${NEXUS_ARTIFACT_URL} \
+    -Dcriteo.repo.username=${MAVEN_USER} \
+    -Dcriteo.repo.password=${MAVEN_PASSWORD}
 
 # python deployment
 deploy_python $PYTHON_PEX_VERSION

--- a/external/docker/criteo-build/build_script.sh
+++ b/external/docker/criteo-build/build_script.sh
@@ -126,7 +126,7 @@ mvn deploy:deploy-file \
 
 # Build and deploy all modules EXCEPT the root-level spark-parent_2.12 module,
 # to avoid generating and uploading unwanted -tests.jar from a POM-only module.
-mvn validate jar:jar jar:test-jar source:jar-no-fork deploy:deploy \
+mvn validate jar:jar jar:test-jar source:jar deploy:deploy \
     --batch-mode \
     -pl "!org.apache.spark:spark-parent_${SCALA_RELEASE}" \
     ${MVN_COMMON_PROPERTIES} \


### PR DESCRIPTION
Fix pom.xml : 

      The spark-parent module is a parent POM (packaging=pom). 
      Still, the global Maven build command was applying jar:test-jar to all modules, resulting in an unintended -tests.jar artifact that incorrectly packaged the pom.xml.
      
      This change excludes spark-parent from the main build and deploy lifecycle and instead deploys its POM manually using the deploy:deploy-file goal with the -Dpackaging=pom option.
      
      This avoids invalid JAR deployment while preserving compatibility with the upstream Spark structure.
      
      Note: this behavior may have been introduced (but not confirmed) after the bump of the Apache parent POM from version 7 to 18, which includes broader plugin defaults.

Fix Scala sources:

    Replace source:jar-no-fork with source:jar in the Maven build to ensure that .scala files
    are correctly included in the generated -sources.jar artifacts.
   
    The source:jar goal includes Scala sources because it forks the build lifecycle
    and properly detects all source directories, unlike jar-no-fork, which skips that setup.
