### PR TITLE
build: fix source JAR to include Scala sources using source:jar

### DIFF
--- a/external/docker/criteo-build/build_script.sh
+++ b/external/docker/criteo-build/build_script.sh
@@ -125,7 +125,7 @@ mvn deploy:deploy-file \
     ${MVN_COMMON_DEPLOY_FILE_PROPERTIES}
 
 # jar artifacts (for parent poms) deployment
-mvn validate jar:jar jar:test-jar source:jar-no-fork deploy:deploy \
+mvn validate jar:jar jar:test-jar source:jar deploy:deploy \
     --batch-mode \
     ${MVN_COMMON_PROPERTIES} \
     -Phadoop-provided \


### PR DESCRIPTION
Replace source:jar-no-fork with source:jar in the Maven build to ensure that .scala files are correctly included in the generated -sources.jar artifacts.

The source:jar goal includes Scala sources because it forks the build lifecycle and properly detects all source directories, unlike jar-no-fork, which skips that setup.