### PR TITLE
[CRITEO] fix key issue while counting rows

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzePartitionCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzePartitionCommand.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.command
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Column, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
@@ -45,7 +46,7 @@ import org.apache.spark.util.collection.Utils
 case class AnalyzePartitionCommand(
     tableIdent: TableIdentifier,
     partitionSpec: Map[String, Option[String]],
-    noscan: Boolean = true) extends LeafRunnableCommand {
+    noscan: Boolean = true) extends LeafRunnableCommand with Logging {
 
   private def getPartitionSpec(table: CatalogTable): Option[TablePartitionSpec] = {
     val normalizedPartitionSpec =
@@ -141,13 +142,25 @@ case class AnalyzePartitionCommand(
     val df = tableDf.filter(Column(filter)).groupBy(partitionColumns: _*).count()
 
     df.collect().map { r =>
-      val partitionColumnValues = partitionColumns.indices.map { i =>
-        if (r.isNullAt(i)) {
-          ExternalCatalogUtils.DEFAULT_PARTITION_NAME
+      val partitionColumnValues =
+        if ("true".equalsIgnoreCase(sparkSession.sessionState.conf.
+          getConfString("spark.sql.hive.convertInsertingPartitionedTable", "true"))) {
+          partitionColumns.indices.map { i =>
+            if (r.isNullAt(i)) {
+              ExternalCatalogUtils.DEFAULT_PARTITION_NAME
+            } else {
+              r.get(i).toString
+            }
+          }
         } else {
-          r.get(i).toString
+          tableMeta.partitionColumnNames.zipWithIndex.map { case (colName, i) =>
+            partitionValueSpec.flatMap(_.get(colName))
+              .getOrElse({
+                logWarning( s"column '$colName' is missing in the given partition " +
+                  s"'$partitionValueSpec', thus no statistics will be collected for it.")
+                ExternalCatalogUtils.DEFAULT_PARTITION_NAME})
+          }
         }
-      }
       val spec = Utils.toMap(tableMeta.partitionColumnNames, partitionColumnValues)
       val count = BigInt(r.getLong(partitionColumns.size))
       (spec, count)


### PR DESCRIPTION
### What changes were proposed in this pull request?
When hiveSerde is used (spark.sql.hive.convertInsertingPartitionedTable=false),
Say that dataset has hour as partition , hour is int and should be formatted in two digit format (hour=06) stored as int with padding inside metastore but rows inside the tables have it as int without the padding. 
when `Analyze Table .. partition(hour='06') compute statistics`   spark use the info inside the rows to generate row count of the given partition since hour is store without padding inside the table , so as spark infer rows to determine the partition key and it rows count it creates partition key that it is different then the one given in the input (that reflect what we have in metastore). Thus the created stats are never saved in metastore due to this format mismatch.

When hiveSerde is not used we would like to keep the logic as it is since this use case will not happen
 


### Why are the changes needed?

to fix the explained bug, and save the partition statistics 



### Does this PR introduce _any_ user-facing change?

'No'.



### How was this patch tested?

local build and test spark via mozart

