### PR TITLE
[CRITEO] Add the possibility to calculate partition stats after creat…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4433,6 +4433,13 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val CRITEO_PARTITION_AUTOSTATS_CALCULATION_ENABLED =
+    buildConf("spark.sql.criteo.partition.autoStats.enabled")
+      .doc("Enables Spark to calculate automatically partition level statistics when new partition is created")
+      .version("3.5.7")
+      .booleanConf
+      .createWithDefault(true)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -5290,6 +5297,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
     getConf(SQLConf.LEGACY_NEGATIVE_INDEX_IN_ARRAY_INSERT)
   }
 
+  def isPartitionAutoStatsEnabled: Boolean = {
+    getConf(SQLConf.CRITEO_PARTITION_AUTOSTATS_CALCULATION_ENABLED)
+  }
   /** ********************** SQLConf functionality methods ************ */
 
   /** Set Spark SQL configuration properties. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -52,6 +52,13 @@ class PathFilterIgnoreNonData(stagingDir: String) extends PathFilter with Serial
 
 object CommandUtils extends Logging {
 
+  def updatePartitionStats(session: SparkSession, table: CatalogTable,
+                           partition: Map[String, Option[String]]): Unit = {
+    if (session.sessionState.conf.isPartitionAutoStatsEnabled) {
+      AnalyzePartitionCommand(table.identifier, partition, false).run(session)
+    }
+  }
+
   /** Change statistics after changing data by commands. */
   def updateTableStats(sparkSession: SparkSession, table: CatalogTable): Unit = {
     val catalog = sparkSession.sessionState.catalog

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -114,7 +114,7 @@ case class InsertIntoHiveTable(
     sparkSession.sessionState.catalog.refreshTable(table.identifier)
 
     CommandUtils.updateTableStats(sparkSession, table)
-
+    CommandUtils.updatePartitionStats(sparkSession, table, partition)
     // It would be nice to just return the childRdd unchanged so insert operations could be chained,
     // however for now we return an empty list to simplify compatibility checks with hive, which
     // does not return anything for insert operations.


### PR DESCRIPTION

Currently very basic stats are generated on table level when partition is created , we added feature (activated by default) that calculate stats at partition level when new partition is created, this avoid us from doing more complicated dev in BDF and less efficient with extra overhead.


### What changes were proposed in this pull request?

Calculate partition stats when new partition is created 



### Why are the changes needed?

we need stats at partition level (like hive) to be able to activate spark optimizer which will have significant impact on performance, also presto//trino will use these stats to optimize its queries 



### Does this PR introduce _any_ user-facing change?

'No'.



### How was this patch tested?

local build , deploy and test in mozart
