### PR TITLE
[CRITEO] prevent having exception while calculating partition stats non partitionned table 

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -54,7 +54,7 @@ object CommandUtils extends Logging {
 
   def updatePartitionStats(session: SparkSession, table: CatalogTable,
                            partition: Map[String, Option[String]]): Unit = {
-    if (session.sessionState.conf.isPartitionAutoStatsEnabled) {
+    if (session.sessionState.conf.isPartitionAutoStatsEnabled && table.partitionColumnNames.nonEmpty) {
       AnalyzePartitionCommand(table.identifier, partition, false).run(session)
     }
   }


### PR DESCRIPTION
…n non partitionned table

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
only try to get partitions on partitionned tables


### Why are the changes needed?
We added a feature that calculate stats at partition level, but we have some cases where table don't have partition columns , currently it causes issue in this case


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
test via mozart
